### PR TITLE
ofSetBackgroundColor(100, 100, 100); in ofApp::setup() instead of ofBackground(100, 100, 100); in ofApp::update()

### DIFF
--- a/pdExample/src/ofApp.cpp
+++ b/pdExample/src/ofApp.cpp
@@ -12,7 +12,8 @@
 
 //--------------------------------------------------------------
 void ofApp::setup() {
-
+	
+	ofSetBackgroundColor(100, 100, 100);
 	ofSetFrameRate(60);
 	ofSetVerticalSync(true);
 	//ofSetLogLevel("Pd", OF_LOG_VERBOSE); // see verbose info inside
@@ -248,7 +249,6 @@ void ofApp::setup() {
 
 //--------------------------------------------------------------
 void ofApp::update() {
-	ofBackground(100, 100, 100);
 	
 	// since this is a test and we don't know if init() was called with
 	// queued = true or not, we check it here


### PR DESCRIPTION
Maybe not important for an example, but its a large performance increase with a small change (at least when running with Emscripten).