### PR TITLE
Update addon_config.mk 

### DIFF
--- a/addon_config.mk
+++ b/addon_config.mk
@@ -28,6 +28,8 @@ common:
 	#ADDON_CFLAGS += -DPDINSTANCE -DPDTHREADS
 	# this is included directly in pd~.c, don't build twice
 	ADDON_SOURCES_EXCLUDE = libs/libpd/pure-data/extra/pd~/binarymsg.c
+	# not needed
+	ADDON_SOURCES_EXCLUDE += libs/libpd/pure-data/src/m_dispatch_gen.c
 
 linux64:
 	ADDON_LIBS_EXCLUDE = libs/libpd/libs


### PR DESCRIPTION
Excludes `m_dispatch_gen.c` which is part of the current PD master branch. Probably it can already be excluded in libpd.
```
# not needed
ADDON_SOURCES_EXCLUDE += libs/libpd/pure-data/src/m_dispatch_gen.c
```